### PR TITLE
mdreflink: fix over-specified version test

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,19 @@
+# Set default behavior to automatically normalize line endings.
+* text=auto
+
+# Explicitly declare text files to always be normalized and converted to native
+# line endings on checkout#
+*.md text
+*.js text
+*.ts text
+*.json text
+*.yml text
+
+# Declare files that will always have CRLF line endings on checkout.
+# *.bat text eol=crlf
+
+# Declare files that will always have LF line endings on checkout.
+*.sh text eol=lf
+
+# Denote all files that are truly binary and should not be modified.
+# *.png binary

--- a/package-lock.json
+++ b/package-lock.json
@@ -39,12 +39,13 @@
         "mdast-util-to-markdown": "^2.1.2",
         "micromark-extension-frontmatter": "^2.0.0",
         "publint": "^0.3.12",
+        "rimraf": "^6.0.1",
         "typescript": "^5.8.3",
         "typescript-eslint": "^8.38.0",
         "vitest": "^3.2.4"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=22.0.0"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -893,6 +894,29 @@
         "url": "https://github.com/sponsors/nzakas"
       }
     },
+    "node_modules/@isaacs/balanced-match": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@isaacs/balanced-match/-/balanced-match-4.0.1.tgz",
+      "integrity": "sha512-yzMTt9lEb8Gv7zRioUilSglI0c0smZ9k5D65677DLWLtWJaXIS3CqcGyUFByYKlnUj6TkjLVs54fBl6+TiGQDQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@isaacs/brace-expansion": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@isaacs/brace-expansion/-/brace-expansion-5.0.0.tgz",
+      "integrity": "sha512-ZT55BDLV0yv0RBm2czMiZ+SqCGO7AvmOM3G/w2xhVPH+te0aKgFjmBvGlL1dH+ql2tgGO3MVrbb3jCKyvpgnxA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@isaacs/balanced-match": "^4.0.1"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
     "node_modules/@isaacs/cliui": {
       "version": "8.0.2",
       "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
@@ -1197,6 +1221,28 @@
         "node": "^10.12.0 || >=12.0.0"
       }
     },
+    "node_modules/@microsoft/eslint-formatter-sarif/node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "deprecated": "Glob versions prior to v9 are no longer supported",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/@microsoft/eslint-formatter-sarif/node_modules/glob-parent": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
@@ -1270,6 +1316,23 @@
       },
       "engines": {
         "node": "*"
+      }
+    },
+    "node_modules/@microsoft/eslint-formatter-sarif/node_modules/rimraf": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+      "deprecated": "Rimraf versions prior to v4 are no longer supported",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/@microsoft/eslint-formatter-sarif/node_modules/strip-ansi": {
@@ -6628,66 +6691,106 @@
       }
     },
     "node_modules/rimraf": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
-      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
-      "deprecated": "Rimraf versions prior to v4 are no longer supported",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-6.0.1.tgz",
+      "integrity": "sha512-9dkvaxAsk/xNXSJzMgFqqMCuFgt2+KsOFek3TMLfo8NCPfWpBmqwyNn5Y+NX56QUYfCtsyhF3ayiboEoUmJk/A==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
-        "glob": "^7.1.3"
+        "glob": "^11.0.0",
+        "package-json-from-dist": "^1.0.0"
       },
       "bin": {
-        "rimraf": "bin.js"
+        "rimraf": "dist/esm/bin.mjs"
+      },
+      "engines": {
+        "node": "20 || >=22"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/rimraf/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
       }
     },
     "node_modules/rimraf/node_modules/glob": {
-      "version": "7.2.3",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
-      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
-      "deprecated": "Glob versions prior to v9 are no longer supported",
+      "version": "11.0.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-11.0.3.tgz",
+      "integrity": "sha512-2Nim7dha1KVkaiF4q6Dj+ngPPMdfvLJEOpZk/jKiUAkqKebpGAWQXAq9z1xu9HKu5lWfqw/FASuccEjyznjPaA==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^3.1.1",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
+        "foreground-child": "^3.3.1",
+        "jackspeak": "^4.1.1",
+        "minimatch": "^10.0.3",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^2.0.0"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
       },
       "engines": {
-        "node": "*"
+        "node": "20 || >=22"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/rimraf/node_modules/jackspeak": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-4.1.1.tgz",
+      "integrity": "sha512-zptv57P3GpL+O0I7VdMJNBZCu+BPHVQUk55Ft8/QCJjTVxrnJHuVuX/0Bl2A6/+2oyR/ZMEuFKwmzqqZ/U5nPQ==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/cliui": "^8.0.2"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/rimraf/node_modules/lru-cache": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.1.0.tgz",
+      "integrity": "sha512-QIXZUBJUx+2zHUdQujWejBkcD9+cs94tLn0+YL8UrCh+D5sCXZ4c7LaEH48pNwRY3MLDgqUFyhlCyjJPf1WP0A==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
     "node_modules/rimraf/node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "version": "10.0.3",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.0.3.tgz",
+      "integrity": "sha512-IPZ167aShDZZUMdRk66cyQAW3qr0WzbHkPdMYa8bzZhlHhO3jALbKdxcaak7W9FfT2rZNpQuUu4Od7ILEpXSaw==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
-        "brace-expansion": "^1.1.7"
+        "@isaacs/brace-expansion": "^5.0.0"
       },
       "engines": {
-        "node": "*"
+        "node": "20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/rimraf/node_modules/path-scurry": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.0.tgz",
+      "integrity": "sha512-ypGJsmGtdXUOeM5u93TyeIEfEhM6s+ljAhrk5vAvSx8uyY/02OvrZnA0YNGUrPXfpJMgI1ODd3nwz8Npx4O4cg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^11.0.0",
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/rollup": {

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     ".": "./dist/transformer.js"
   },
   "scripts": {
-    "build": "rm -rf dist && tsc && esbuild src/index.ts --bundle --platform=node --format=esm --outfile=dist/index.js",
+    "build": "rimraf dist && tsc && esbuild src/index.ts --bundle --platform=node --format=esm --outfile=dist/index.js",
     "start": "node dist/index.js",
     "prepublishOnly": "npm run build && npm run lint && npm run lint:package",
     "test": "npm run build && vitest run",
@@ -64,6 +64,7 @@
     "mdast-util-to-markdown": "^2.1.2",
     "micromark-extension-frontmatter": "^2.0.0",
     "publint": "^0.3.12",
+    "rimraf": "^6.0.1",
     "typescript": "^5.8.3",
     "typescript-eslint": "^8.38.0",
     "vitest": "^3.2.4"

--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -4,6 +4,8 @@ import {promises as fs} from 'fs';
 import {run, Console} from './index.js';
 
 describe('CLI entrypoint', () => {
+  const VERSION_PATTERN = /^\d+\.\d+\.\d+/;
+
   let consoleSpy: Console;
   let processExitSpy: MockInstance;
   let processStdoutWriteSpy: MockInstance;
@@ -52,7 +54,8 @@ describe('CLI entrypoint', () => {
   it('should show version when --version flag is used', async () => {
     await run({_: [], version: true}, consoleSpy);
 
-    expect(consoleSpy.log).toHaveBeenCalledWith('0.0.1');
+    expect(consoleSpy.log).toHaveBeenCalledWith(
+        expect.stringMatching(VERSION_PATTERN));
     expect(processStdoutWriteSpy).not.toHaveBeenCalled();
     expect(writeFileMock).not.toHaveBeenCalled();
   });
@@ -60,7 +63,8 @@ describe('CLI entrypoint', () => {
   it('should show version when -v flag is used', async () => {
     await run({_: [], v: true}, consoleSpy);
 
-    expect(consoleSpy.log).toHaveBeenCalledWith('0.0.1');
+    expect(consoleSpy.log).toHaveBeenCalledWith(
+        expect.stringMatching(VERSION_PATTERN));
     expect(processStdoutWriteSpy).not.toHaveBeenCalled();
     expect(writeFileMock).not.toHaveBeenCalled();
   });
@@ -79,24 +83,25 @@ describe('CLI entrypoint', () => {
     expect(processStdoutWriteSpy).toHaveBeenCalled();
   });
 
-  it('should output stats to stderr when using stdout for content', async () => {
-    const inputMarkdown = `[test](url)`;
-    const filePath = 'test.md';
+  it('should output stats to stderr when using stdout for content',
+      async () => {
+        const inputMarkdown = `[test](url)`;
+        const filePath = 'test.md';
 
-    readFileMock.mockResolvedValue(inputMarkdown);
+        readFileMock.mockResolvedValue(inputMarkdown);
 
-    await run({_: [filePath], stats: true}, consoleSpy);
+        await run({_: [filePath], stats: true}, consoleSpy);
 
-    expect(consoleSpy.error).toHaveBeenCalledWith('Links converted: 1');
-    expect(consoleSpy.error).toHaveBeenCalledWith('Conflicts found: 0');
-    expect(consoleSpy.error).toHaveBeenCalledWith('Definitions added: 1');
+        expect(consoleSpy.error).toHaveBeenCalledWith('Links converted: 1');
+        expect(consoleSpy.error).toHaveBeenCalledWith('Conflicts found: 0');
+        expect(consoleSpy.error).toHaveBeenCalledWith('Definitions added: 1');
 
-    expect(processStdoutWriteSpy).toHaveBeenCalledWith(
-        expect.stringContaining('[test]'));
+        expect(processStdoutWriteSpy).toHaveBeenCalledWith(
+            expect.stringContaining('[test]'));
 
-    expect(processStdoutWriteSpy).not.toHaveBeenCalledWith(
-        expect.stringContaining('Links converted'));
-  });
+        expect(processStdoutWriteSpy).not.toHaveBeenCalledWith(
+            expect.stringContaining('Links converted'));
+      });
 
   it('should process a file and write to stdout', async () => {
     const inputMarkdown = `[hello](world)`;

--- a/src/normalize-line-endings.ts
+++ b/src/normalize-line-endings.ts
@@ -1,0 +1,12 @@
+// Normalize line endings for cross-platform compatibility (registered in
+// vitest.config.ts).
+import {expect} from 'vitest';
+
+// Custom matcher to normalize line endings in snapshots.
+expect.addSnapshotSerializer({
+  test: (value: unknown): value is string => typeof value === 'string',
+  serialize: (value: string): string => {
+    // Use to LF (\n) for consistent snapshots.
+    return value.replace(/\r\n/g, '\n').replace(/\r/g, '\n');
+  },
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -6,5 +6,7 @@ export default defineConfig({
       // Suppress printing type information in the snapshots for concision.
       printBasicPrototype: false,
     },
+    // Set up cross-platform line ending normalization
+    setupFiles: ['./src/normalize-line-endings.ts'],
   },
 });


### PR DESCRIPTION
The version tests now are data-driven (traps) with version verification.

The testing framework operates in a line ending-agnostic way with respect to fixtures, snapshots, and similar.