### PR TITLE
mdreflink: disable end-to-end test on Windows

### DIFF
--- a/.github/workflows/compatibility.yml
+++ b/.github/workflows/compatibility.yml
@@ -44,6 +44,7 @@ jobs:
         run: npm run test
 
       - name: Run E2E tests
+        if: runner.os != 'Windows'
         run: npm run test:e2e
 
       - name: Test CLI directly (Unix)


### PR DESCRIPTION
This test simply won't be ported.