### PR TITLE
mdreflink: prepare v0.0.3 release

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mdreflink",
-  "version": "0.0.1",
+  "version": "0.0.3",
   "description": "Convert Markdown inline links to reference links with smart placement",
   "type": "module",
   "main": "dist/transformer.js",


### PR DESCRIPTION
Like v0.0.2, no functional changes.  Merely to accommodate CI/CD working correctly and to test deployment to npm on tagging.