### PR TITLE
fix: drop legacy mdast use

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,6 @@
       "version": "0.0.2",
       "license": "Apache-2.0",
       "dependencies": {
-        "mdast": "^3.0.0",
         "mdast-util-to-string": "^4.0.0",
         "minimist": "^1.2.8",
         "remark-frontmatter": "^5.0.0",
@@ -3393,13 +3392,6 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
-    },
-    "node_modules/mdast": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/mdast/-/mdast-3.0.0.tgz",
-      "integrity": "sha512-xySmf8g4fPKMeC07jXGz971EkLbWAJ83s4US2Tj9lEdnZ142UP5grN73H1Xd3HzrdbU5o9GYYP/y8F9ZSwLE9g==",
-      "deprecated": "`mdast` was renamed to `remark`",
-      "license": "MIT"
     },
     "node_modules/mdast-util-from-markdown": {
       "version": "2.0.2",

--- a/package.json
+++ b/package.json
@@ -74,7 +74,6 @@
     "dist/*.d.ts"
   ],
   "dependencies": {
-    "mdast": "^3.0.0",
     "mdast-util-to-string": "^4.0.0",
     "minimist": "^1.2.8",
     "remark-frontmatter": "^5.0.0",

--- a/src/transformer.ts
+++ b/src/transformer.ts
@@ -1,4 +1,4 @@
-import {
+import type {
   Root, Link, LinkReference, Definition, Node, RootContent,
   PhrasingContent, Text, Parents,
 } from 'mdast';


### PR DESCRIPTION
mdast has been replaced in favor of remark.