### PR TITLE
fix(transformer): prevent escaping fragment links

### DIFF
--- a/src/__fixtures__/should_not_mangle_id_link.md
+++ b/src/__fixtures__/should_not_mangle_id_link.md
@@ -1,0 +1,3 @@
+# Another take! {#another-take}
+
+[Oh why don't you feel the beat?](#another-take)

--- a/src/__snapshots__/should_not_mangle_id_link.md.snap
+++ b/src/__snapshots__/should_not_mangle_id_link.md.snap
@@ -1,0 +1,5 @@
+# Another take! {#another-take}
+
+[Oh why don't you feel the beat?]
+
+[Oh why don't you feel the beat?]: #another-take

--- a/src/transformer.ts
+++ b/src/transformer.ts
@@ -18,8 +18,8 @@ import {frontmatterToMarkdown} from 'mdast-util-frontmatter';
 const simpleTextHandler = (node: Text, parent: Parents | undefined,
     state: State, info: Info): string => {
   const isLinkContext = state.stack.includes('link') ||
-      state.stack.includes('linkReference') ||
-      state.stack.includes('definition');
+    state.stack.includes('linkReference') ||
+    state.stack.includes('definition');
 
   if (isLinkContext) {
     return state.safe(node.value, info);
@@ -64,6 +64,12 @@ const definitionHandler = (node: Definition, parent: Parents | undefined,
     return `[${node.identifier}]: ${url}${safeTitle}`;
   }
 
+  // If the URL is a fragment-only link, do not escape it.
+  if (url.startsWith('#')) {
+    const safeTitle = node.title ? ` "${state.safe(node.title, info)}"` : '';
+    return `[${node.identifier}]: ${url}${safeTitle}`;
+  }
+
   // For non-Hugo URLs, manually construct the definition to avoid recursion.
   const safeUrl = state.safe(node.url, info);
   const safeTitle = node.title ? ` "${state.safe(node.title, info)}"` : '';
@@ -99,9 +105,9 @@ const DISALLOWED_INNER_LINK_ELEMENTS: string[] = [
  * Statistics about the transformation process.
  */
 export interface TransformStats {
-    linksConverted: number;
-    conflictsFound: number;
-    definitionsAdded: number;
+  linksConverted: number;
+  conflictsFound: number;
+  definitionsAdded: number;
 }
 
 /**
@@ -270,7 +276,7 @@ export function transformLinksToReferences(tree: Root): { tree: Root; stats: Tra
       // Use the identifier from the linkReference.
       const linkIdentifier = linkNode.identifier;
       if (conflictingTexts.has(linkText) ||
-          definitionCreatedFor.has(linkIdentifier)) {
+        definitionCreatedFor.has(linkIdentifier)) {
         return;
       }
 


### PR DESCRIPTION
This commit fixes a defect that was discovered late in the game whereby fragment link destinations end up destructively escaped.

This fixes #20.