### PR TITLE
fix: linked images should be ignored

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,6 +188,8 @@ This creates a tarball showing exactly what files will be included in the
 published package. Remember to clean up the generated .tgz file
 afterward.
 
+[publint]: https://publint.dev/
+
 ### Release Tagging
 
 This project uses automated releases triggered by Git tags. Tags must follow the `v{version}` format (e.g., `v1.2.3`) to match JavaScript ecosystem conventions.
@@ -217,11 +219,9 @@ This project uses automated releases triggered by Git tags. Tags must follow the
 
 The GitHub Actions workflow will automatically:
 
-- Run all tests (unit and e2e)
-- Validate the package
-- Publish to npm with provenance
-- Create a GitHub release
+* Run all tests (unit and e2e)
+* Validate the package
+* Publish to npm with provenance
+* Create a GitHub release
 
 **Note:** The tag version (without 'v' prefix) must exactly match the version in `package.json` or the release will fail.
-
-[publint]: https://publint.dev/

--- a/src/__fixtures__/should_ignore_image_links.md
+++ b/src/__fixtures__/should_ignore_image_links.md
@@ -1,0 +1,1 @@
+[![CI](https://github.com/matttproud/mdreflink/actions/workflows/ci.yml/badge.svg)](https://github.com/matttproud/mdreflink/actions/workflows/ci.yml)

--- a/src/__snapshots__/should_ignore_image_links.md.snap
+++ b/src/__snapshots__/should_ignore_image_links.md.snap
@@ -1,0 +1,1 @@
+[![CI](https://github.com/matttproud/mdreflink/actions/workflows/ci.yml/badge.svg)](https://github.com/matttproud/mdreflink/actions/workflows/ci.yml)

--- a/src/ast-info-collector.ts
+++ b/src/ast-info-collector.ts
@@ -136,7 +136,21 @@ export class AstInfoCollector {
     this.headingNodeToId.set(h, this.headingSeq);
   }
 
+  private hasImageChild(link: Link | LinkReference): boolean {
+    return link.children.some((child) => child.type === "image");
+  }
+
+  private isAllowed(link: Link | LinkReference): boolean {
+    if (this.hasImageChild(link)) {
+      return false;
+    }
+    return true;
+  }
+
   private ingestLinkNode(l: Link | LinkReference, parent?: Parents): void {
+    if (!this.isAllowed(l)) {
+      return;
+    }
     const linkName = normalizeLinkName(l);
     if (!linkName) {
       return;


### PR DESCRIPTION
This commit introduces filter logic to ensure that links that contain images within them are ignored, since these are not real candidates to be turned into reference links.

Closes #29